### PR TITLE
修正Confluence升级后，不能增加/更新文档问题

### DIFF
--- a/api_content.go
+++ b/api_content.go
@@ -108,7 +108,14 @@ func (cli *Client) ContentCreateInSpace(contentType, space, parentId, title, dat
 
 	//设置父页面
 	if parentId != "" {
-		content.Ancestors = []Content{Content{Id: parentId}}
+		content.Ancestors = []Content{
+			{
+				Id: parentId,
+				Space: Space{
+					Key: content.Space.Key,
+				},
+			},
+		}
 	}
 
 	resp, err := cli.ApiPOST("/content", content)
@@ -216,7 +223,14 @@ func (cli *Client) DrawFile(space, parentId, title, wikiDirPrefix, data string) 
 
 		//设置父页面
 		if parentId != "" {
-			content.Ancestors = []Content{Content{Id: parentId}}
+			content.Ancestors = []Content{
+				{
+					Id: parentId,
+					Space: Space{
+						Key: content.Space.Key,
+					},
+				},
+			}
 		}
 
 		return cli.ContentUpdate(content)
@@ -283,7 +297,14 @@ func (cli *Client) DrawFileWithNoteMacro(space, parentId, title, wikiDirPrefix, 
 
 		//设置父页面
 		if parentId != "" {
-			content.Ancestors = []Content{Content{Id: parentId}}
+			content.Ancestors = []Content{
+				{
+					Id: parentId,
+					Space: Space{
+						Key: content.Space.Key,
+					},
+				},
+			}
 		}
 
 		return cli.ContentUpdate(content)
@@ -379,7 +400,14 @@ func (cli *Client) DrawFileWithNewNoteMacro(options *DrawModifyPageOption) (Cont
 
 		//设置父页面
 		if options.ParentId != "" {
-			content.Ancestors = []Content{{Id: options.ParentId}}
+			content.Ancestors = []Content{
+				{
+					Id: options.ParentId,
+					Space: Space{
+						Key: content.Space.Key,
+					},
+				},
+			}
 		}
 
 		return cli.ContentUpdate(content)

--- a/request.go
+++ b/request.go
@@ -114,7 +114,7 @@ func (cli *Client) ApiPOSTFiles(path string, files []string) (*http.Response, er
 	w.Close()
 
 	header := url.Values{
-		"X-Atlassian-Token": {"nocheck"},
+		"X-Atlassian-Token": {"no-check"},
 		"Content-Type":      {w.FormDataContentType()},
 	}
 


### PR DESCRIPTION
修正Confluence升级后，不能增加/更新文档问题。
在调conflune content相关接口时，给Ancestors参数加上space key。并把nocheck改为no-check。